### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@documenso/sdk-typescript",
   "version": "0.8.1",
   "author": "Speakeasy",
+  "license": "MIT",
   "bin": {
     "mcp": "bin/mcp-server.js"
   },


### PR DESCRIPTION
## Summary

- add MIT license metadata to the package manifest
- align npm metadata with the repository license

## Verification

- `npm view @documenso/sdk-typescript@latest name version license repository homepage bugs --json`
- `node -e "const p=require('./package.json'); if (p.license !== 'MIT') throw new Error('license mismatch'); console.log(p.name, p.version, p.license)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
